### PR TITLE
名前空間の移動

### DIFF
--- a/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Packet/Packet.h
+++ b/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Packet/Packet.h
@@ -13,7 +13,7 @@ namespace Packet
  * @class CPacket
  * @brief パケット基底クラス
  */
-class CPacket : public ISerializable
+class CPacket : public Serializable::ISerializable
 {
 
 public:

--- a/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Packet/PacketHeader.h
+++ b/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Packet/PacketHeader.h
@@ -13,7 +13,7 @@ namespace Packet
  * @class CPacketHeader
  * @brief パケットヘッダ
  */
-class CPacketHeader : public ISerializable
+class CPacketHeader : public Serializable::ISerializable
 {
 
 public:

--- a/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Serializable/Serializable.h
+++ b/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Serializable/Serializable.h
@@ -1,9 +1,13 @@
 #ifndef __SERIALIZABLE_H__
 #define __SERIALIZABLE_H__
 
-#include "../Stream/MemoryStream.h"
-
 namespace YanaPOnlineUtil
+{
+namespace Stream
+{
+class IMemoryStream;
+}
+namespace Serializable
 {
 
 /**
@@ -30,6 +34,7 @@ public:
 
 };
 
+}
 }
 
 #endif		// #ifndef __SERIALIZABLE_H__

--- a/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Stream/MemorySizeCaliculator.h
+++ b/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Stream/MemorySizeCaliculator.h
@@ -93,12 +93,12 @@ public:
 	virtual bool Serialize(std::string *pData) override;
 
 	/**
-	 * @fn virtual bool Serialize(ISerializable *pData) override
+	 * @fn virtual bool Serialize(Serializable::ISerializable *pData) override
 	 * @brief シリアライズ可能なオブジェクトのシリアライズ
 	 * @param[in] pData データ
 	 * @return 成功したらtrueを返す。
 	 */
-	virtual bool Serialize(ISerializable *pData) override { return pData->Serialize(this); }
+	virtual bool Serialize(Serializable::ISerializable *pData) override { return pData->Serialize(this); }
 
 	/**
 	 * @fn virtual bool Serialize(void *pData, unsigned int DataSize) override

--- a/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Stream/MemoryStream.h
+++ b/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Stream/MemoryStream.h
@@ -5,9 +5,10 @@
 
 namespace YanaPOnlineUtil
 {
-
+namespace Serializable
+{
 class ISerializable;
-
+}
 namespace Stream
 {
 
@@ -106,12 +107,12 @@ public:
 	virtual bool Serialize(std::string *pData) = 0;
 
 	/**
-	 * @fn virtual bool Serialize(ISerializable *pData) = 0
+	 * @fn virtual bool Serialize(Serializable::ISerializable *pData) = 0
 	 * @brief シリアライズ可能なオブジェクトのシリアライズ
 	 * @param[in] pData データ
 	 * @return 成功したらtrueを返す。
 	 */
-	virtual bool Serialize(ISerializable *pData) = 0;
+	virtual bool Serialize(Serializable::ISerializable *pData) = 0;
 
 	/**
 	 * @fn virtual bool Serialize(void *pData, unsigned int DataSize) = 0

--- a/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Stream/MemoryStreamReader.h
+++ b/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Stream/MemoryStreamReader.h
@@ -95,12 +95,12 @@ public:
 	virtual bool Serialize(std::string *pData) override;
 
 	/**
-	 * @fn virtual bool Serialize(ISerializable *pData) override
+	 * @fn virtual bool Serialize(Serializable::ISerializable *pData) override
 	 * @brief シリアライズ可能なオブジェクトのシリアライズ
 	 * @param[in] pData データ
 	 * @return 成功したらtrueを返す。
 	 */
-	virtual bool Serialize(ISerializable *pData) override { return pData->Serialize(this); }
+	virtual bool Serialize(Serializable::ISerializable *pData) override { return pData->Serialize(this); }
 
 	/**
 	 * @fn virtual bool Serialize(void *pData, unsigned int DataSize) override

--- a/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Stream/MemoryStreamWriter.h
+++ b/CPP/YanaPOnlineUtil/include/YanaPOnlineUtil/Stream/MemoryStreamWriter.h
@@ -94,12 +94,12 @@ public:
 	virtual bool Serialize(std::string *pData) override;
 
 	/**
-	 * @fn virtual bool Serialize(ISerializable *pData) override
+	 * @fn virtual bool Serialize(Serializable::ISerializable *pData) override
 	 * @brief シリアライズ可能なオブジェクトのシリアライズ
 	 * @param[in] pData データ
 	 * @return 成功したらtrueを返す。
 	 */
-	virtual bool Serialize(ISerializable *pData) override { return pData->Serialize(this); }
+	virtual bool Serialize(Serializable::ISerializable *pData) override { return pData->Serialize(this); }
 
 	/**
 	 * @fn virtual bool Serialize(void *pData, unsigned int DataSize) override


### PR DESCRIPTION
ISerializableインタフェースがYanaPOnlineUtil名前空間直下に置いてあったのでSerializable名前空間に移動。